### PR TITLE
Remove the Drupal version number

### DIFF
--- a/content/node.1413881a-46d0-4c70-8c1b-f088f7f85c8d.yml
+++ b/content/node.1413881a-46d0-4c70-8c1b-f088f7f85c8d.yml
@@ -41,11 +41,11 @@ body:
   - value: |
       <p>This guide will describe how you can use traditional Drupal hosting, Tome Static, and Netlify to have a normal content editing experience while still running static html on your public-facing site.</p>
 
-      <p>First, you'll need to host a Drupal 8 site somewhere. For my testing, I've used&nbsp;<a href="https://pantheon.io/">Pantheon</a>, which provides a free-tier and the ability to lock down environments, which is important for keeping people away from your content editing domain.</p>
+      <p>First, you'll need to host a Drupal site somewhere. For my testing, I've used&nbsp;<a href="https://pantheon.io/">Pantheon</a>, which provides a free-tier and the ability to lock down environments, which is important for keeping people away from your content editing domain.</p>
 
       <ol>
       	<li>
-      	<p>Assuming you have a basic Drupal 8 installation, run this command&nbsp;from where your site's "composer.json" file lives: "composer require drupal/tome drupal/tome_netlify".</p>
+      	<p>Assuming you have a basic Drupal installation, run this command&nbsp;from where your site's "composer.json" file lives: "composer require drupal/tome drupal/tome_netlify".</p>
       	</li>
       	<li>
       	<p>Edit your site "settings.php" file and set the "tome_static_directory" setting to a writeable directory on your hosting provider. For Pantheon, I add this block of code:<br />

--- a/content/node.73c229a9-2979-4a36-a6ba-32c81080bd58.yml
+++ b/content/node.73c229a9-2979-4a36-a6ba-32c81080bd58.yml
@@ -45,7 +45,7 @@ body:
 
       <p>Having a performant, secure Drupal site is hard. It requires careful maintenance, a proper use of caching, and hosting add-ons like Varnish, Memcached, Redis, and a CDN to get the most out of your site. It also means that production deploys need to not take your site down, and be easy to revert. For a large organization or an enterprise hosting company these may seem like solved problems, but for many Drupal users this is still hard to pull off.</p>
 
-      <p>This is where Tome can come in. Using a sub-module of Tome, Tome Static, any Drupal 8 site can become a static site. You can still make full use of Drupal's backend, and continue to use your traditional Drupal theme, but have a static site running in production. The performance and security benefits for this are huge, for small and large sites&nbsp;alike.</p>
+      <p>This is where Tome can come in. Using a sub-module of Tome, Tome Static, any Drupal site can become a static site. You can still make full use of Drupal's backend, and continue to use your traditional Drupal theme, but have a static site running in production. The performance and security benefits for this are huge, for small and large sites&nbsp;alike.</p>
 
       <h2>Storing everything in version control</h2>
 
@@ -61,7 +61,7 @@ body:
 
       <h2>Archiving a site</h2>
 
-      <p>If you have an older Drupal 8 site that's no longer updated, or updated very rarely, migrating to Tome may be a good option. You can follow the existing documentation for installing Tome to an existing site, then turn the production site off or point the production domain to your static site.</p>
+      <p>If you have an older Drupal site that's no longer updated, or updated very rarely, migrating to Tome may be a good option. You can follow the existing documentation for installing Tome to an existing site, then turn the production site off or point the production domain to your static site.</p>
 
       <h2>Migrating away from Drupal or to a new Drupal site</h2>
 

--- a/content/node.81bc02f2-d2eb-422e-afb2-e788af8a426b.yml
+++ b/content/node.81bc02f2-d2eb-422e-afb2-e788af8a426b.yml
@@ -38,7 +38,7 @@ path:
   - alias: /home
     langcode: en
 field_description:
-  - value: 'The homepage for Tome, a static site generator for Drupal 8.'
+  - value: 'The homepage for Tome, a static site generator for Drupal.'
 field_paragraphs:
   - target_type: paragraph
     target_uuid: 78b3effa-9f0f-4229-93e2-4ef5b006ffb8

--- a/content/node.9e896df2-fbb0-4709-97be-63ce76fbb25d.yml
+++ b/content/node.9e896df2-fbb0-4709-97be-63ce76fbb25d.yml
@@ -39,7 +39,7 @@ path:
     langcode: en
 body:
   - value: |
-      <p>If you have an existing Drupal 8 site, installing Tome is fairly straightforward. This guide will take you through the process of installing Tome or Tome Static.</p>
+      <p>If you have an existing Drupal site, installing Tome is fairly straightforward. This guide will take you through the process of installing Tome or Tome Static.</p>
 
       <h2>Installing Tome Static</h2>
 

--- a/content/paragraph.78b3effa-9f0f-4229-93e2-4ef5b006ffb8.yml
+++ b/content/paragraph.78b3effa-9f0f-4229-93e2-4ef5b006ffb8.yml
@@ -27,5 +27,5 @@ field_headline:
 field_link: {  }
 field_text:
   - value: |
-      <p>A static site generator for Drupal 9</p>
+      <p>A static site generator for Drupal</p>
     format: rich_text


### PR DESCRIPTION
Tome works with Drupal 10 and 11, so remove the Drupal version number as it could cause confusion or prevent potential users from using Tome.